### PR TITLE
added more commands

### DIFF
--- a/ld.lld.1
+++ b/ld.lld.1
@@ -1,16 +1,18 @@
 .Dd January 7, 2017
 .Dt LD.LLD 1
+.Os
 .Sh Name
 .Nm ld.lld
-.Nd linker from the LLVM project
+.Nd Linker from the LLVM project
 .Sh SYNOPSIS
-.Nm
+.Nm ld.lld
 .Op Fl [options]
 .Ar objfile
 .Sh DESCRIPTION
 .Nm
 is a drop-in replacement for the GNU linkers.  That accepts the same
 command line arguments and linker scripts as GNU.
+
 .Pp
 The following options are available:
 .Bl -tag -width indent
@@ -28,19 +30,19 @@ Do not link against shared libraries
 Bind defined function symbols locally
 .It Fl -Bsymbolic
 Bind defined symbols locally
-.It Fl -build-id = Ar value
+.It Fl -build-id= Ns Ar value
 Generate build ID note
 .It Fl -build-id
 Generate build ID note
-.It Fl -color-diagnostics = Ar value
+.It Fl -color-diagnostics= Ns Ar value
 Use colors in diagnostics.
 .It Fl -color-diagnostics
 Use colors in diagnostics.
-.It Fl -compress-debug-sections = Ar value
+.It Fl -compress-debug-sections= Ns Ar value
 Compress DWARF debug sections.
 .It Fl -define-common
 Assign space to common symbols.
-.It Fl -defsym= Ar value
+.It Fl -defsym= Ns Ar value
 Define a symbol alias.
 .It Fl -demangle
 Demangle symbol names.
@@ -56,4 +58,192 @@ Keep all symbols in the symbol table.
 Which dynamic linker to use.
 .It Fl -dynamic-list Ar value
 Read a list of dynamic symbols.
+.It Fl -eh-frame-hdr
+Request creation of .eh_frame_hdr section and PT_GNU_EH_FRAME segment header
+.It Fl -emit-relocs
+Generate relocations in output
+.It  --enable-new-dtags
+Enable new dynamic tags
+.It Fl -end-lib
+End a grouping of objects that should be treated as if they were together in an archive
+.It Fl -entry Ar entry
+Name of entry point symbol
+.It Fl -error-limit Ar value
+Maximum number of errors to emit before stopping (0 = no limit)
+.It Fl -error-unresolved-symbols
+Report unresolved symbols as errors
+.It Fl -exclude-libs Ar value
+Exclude static libraries from automatic export
+.It Fl -export-dynamic-symbol Ar value
+Put a symbol in the dynamic symbol table
+.It Fl -export-dynamic
+Put symbols in the dynamic symbol table
+.It Fl -fatal-warnings
+Treat warnings as errors
+.It Fl -filter= Ns Ar value
+Set DT_FILTER field to the specified name
+.It Fl -fini Ar symbol
+Specify a finalizer function
+.It Fl -format= Ns Ar input-format
+Change the input format of the inputs following this option
+.It Fl -full-shutdown
+Perform a full shutdown instead of calling _exit
+.It Fl -gc-sections
+Enable garbage collection of unused sections
+.It Fl -gdb-index
+Generate .gdb_index section
+.It Fl -hash-style Ar value
+Specify hash style (sysv, gnu or both)
+.It Fl -help
+Print option help
+.It Fl -icf=all
+Enable identical code folding
+.It Fl -icf=none
+Disable identical code folding
+.It Fl -image-base= Ns Ar value
+Set the base address
+.It Fl -init Ar symbol
+Specify an initializer function
+.It Fl -lto-aa-pipeline= Ns Ar value
+AA pipeline to run during LTO. Used in conjunction with -lto-newpm-passes
+.It Fl -lto-newpm-passes= Ns Ar value
+Passes to run during LTO
+.It Fl -lto-O Ar opt-level
+Optimization level for LTO
+.It Fl -lto-partitions= Ns Ar value
+Number of LTO codegen partitions
+.It Fl L Ar dir
+Add a directory to the library search path
+.It Fl l Ar libName
+Root name of library to use
+.It Fl -Map Ar value
+Print a link map to the specified file
+.It Fl m Ar value
+Set target emulation
+.It Fl -no-as-needed
+Always DT_NEEDED for shared libraries
+.It Fl -no-color-diagnostics
+Do not use colors in diagnostics
+.It Fl -no-define-common
+Do not assign space to common symbols
+.It Fl -no-demangle
+Do not demangle symbol names
+.It Fl -no-dynamic-linker
+Inhibit output of .interp section
+.It Fl -no-gc-sections
+Disable garbage collection of unused sections
+.It Fl -no-gnu-unique
+Disable STB_GNU_UNIQUE symbol binding
+.It Fl -no-rosegment
+Do not put read-only non-executable sections in their own segment
+.It Fl -no-threads
+Do not run the linker multi-threaded
+.It Fl -no-undefined-version
+Report version scripts that refer undefined symbols
+.It Fl -no-undefined
+Report unresolved symbols even if the linker is creating a shared library
+.It Fl -no-whole-archive
+Restores the default behavior of loading archive members
+.It Fl -noinhibit-exec
+Retain the executable output file whenever it is still usable
+.It Fl -nopie
+Do not create a position independent executable
+.It Fl -nostdlib
+Only search directories specified on the command line
+.It Fl -oformat Ar format
+Specify the binary format for the output object file
+.It Fl -omagic
+Set the text and data sections to be readable and writable
+.It Fl -opt-remarks-filename Ar value
+YAML output file for optimization remarks
+.It Fl -opt-remarks-with-hotness
+Include hotness informations in the optimization remarks file
+.It Fl O Ar value
+Optimize output file size
+.It Fl o Ar path
+Path to file to write output
+.It Fl -pie
+Create a position independent executable
+.It Fl -print-gc-sections
+List removed unused sections
+.It Fl -print-map
+Print a link map to the standard output
+.It Fl -relocatable
+Create relocatable object file
+.It Fl -reproduce Ar value
+Dump linker invocation and input files for debugging
+.It Fl -retain-symbols-file= Ns Ar file
+Retain only the symbols listed in the file
+.It Fl -rpath Ar value
+Add a DT_RUNPATH to the output
+.It Fl -rsp-quoting= Ns Ar value
+Quoting style for response files. Values supported: windows|posix
+.It Fl -script Ar value
+Read linker script
+.It Fl -section-start Ar address
+Set address of section
+.It Fl -shared
+Build a shared object
+.It Fl -soname= Ns Ar value
+Set DT_SONAME
+.It Fl -sort-section Ar value
+Specifies sections sorting rule when linkerscript is used
+.It Fl -start-lib
+Start a grouping of objects that should be treated as if they were together in an archive
+.It Fl -strip-all
+Strip all symbols
+.It Fl -strip-debug
+Strip debugging information
+.It Fl -symbol-ordering-file Ar value
+Layout sections in the order specified by symbol file
+.It Fl -sysroot= Ns Ar value
+Set the system root
+.It Fl -target1-abs
+Interpret R_ARM_TARGET1 as R_ARM_ABS32
+.It Fl -target1-rel
+Interpret R_ARM_TARGET1 as R_ARM_REL32
+.It Fl -target2=type
+Interpret R_ARM_TARGET2 as type, where type is one of rel, abs, or got-rel
+.It Fl -Tbss Ar value
+Same as --section-start with .bss as the sectionname
+.It Fl -Tdata Ar value
+Same as --section-start with .data as the sectionname
+.It Fl -thinlto-cache-dir= Ns Ar value
+Path to ThinLTO cached object file directory
+.It Fl -thinlto-cache-policy Ar value
+Pruning policy for the ThinLTO cache
+.It Fl -thinlto-jobs= Ns Ar value
+Number of ThinLTO jobs
+.It Fl -threads
+Run the linker multi-threaded
+.It Fl -trace-symbol Ar value
+Trace references to symbols
+.It Fl -trace
+Print the names of the input files
+.It Fl -Ttext Ar value
+Same as --section-start with .text as the sectionname
+.It Fl -undefined Ar value
+Force undefined symbol during linking
+.It Fl -unresolved-symbols= Ns Ar value
+Determine how to handle unresolved symbols
+.It Fl -verbose
+Verbose mode
+.It Fl -version-script Ar value
+Read a version script
+.It Fl -version
+Display the version number and exit
+.It Fl v
+Display the version number
+.It Fl -warn-common
+Warn about duplicate common symbols
+.It Fl -warn-unresolved-symbols
+Report unresolved symbols as warnings
+.It Fl -whole-archive
+Force load of all members in a static library
+.It Fl -wrap Ar symbol
+Use wrapper functions for symbol
+.It Fl z Ar option
+Linker option extensions
+.Sh IMPLEMENTATION NOTES
+ld.lld: supported targets: elf32-i386 elf32-iamcu elf32-littlearm elf32-ntradbigmips elf32-ntradlittlemips elf32-powerpc elf32-tradbigmips elf32-tradlittlemips elf32-x86-64 elf64-amdgpu elf64-littleaarch64 elf64-powerpc elf64-tradbigmips elf64-tradlittlemips elf64-x86-64
 


### PR DESCRIPTION
for the commands that had the following form: `command -flag=value` (where the flag takes a value), what Ed came up with was to put: `.It Fl command= Ns Ar value`. 
I couldn't find any better way of doing it in man mdoc. I tried looking up for such commands in the existing mdoc documents but there wasn't any flag with a value option.